### PR TITLE
Update Arrays 3 solutions link to the solutions slide deck

### DIFF
--- a/algorithms/algorithm-practice-sessions-10.md
+++ b/algorithms/algorithm-practice-sessions-10.md
@@ -5,4 +5,4 @@
 ### Resources
 
 * [Problems](https://docs.google.com/presentation/d/1E3T-LxBdXNnakhzWTe6cjjF_JX2WfbPfsjQedtOYSh4/edit?usp=sharing)
-* [Solutions](https://docs.google.com/presentation/d/1E3T-LxBdXNnakhzWTe6cjjF_JX2WfbPfsjQedtOYSh4/edit?usp=sharing)
+* [Solutions](https://docs.google.com/presentation/d/1_x6AbPekgGUbN-i9KnhJpIKd0rXXyaFQLYtpG4mPNWI/edit?usp=sharing)


### PR DESCRIPTION
Both the problems and solutions links in Arrays 3 was pointing to the problems slide deck, updating the solutions link to https://docs.google.com/presentation/d/1_x6AbPekgGUbN-i9KnhJpIKd0rXXyaFQLYtpG4mPNWI/edit?usp=sharing.