### PR TITLE
Fix typos in Amazon crash courses

### DIFF
--- a/internship-prep/git_video_course.md
+++ b/internship-prep/git_video_course.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-At Ada, we teach the basics of using git and github for collaboration. Every company has different norms and expectations around git, gihub, and other version control systems. The video course linked below was created by Alyssa Hursh, an Ada alum and mentor and software engineer at Amazon. This comprehensive git course is based on Alyssa's extensive experience mentoring Ada interns at Amazon. Completion of this course will help set up Ada interns for success at Amazon.
+At Ada, we teach the basics of using Git and GitHub for collaboration. Every company has different norms and expectations around Git, GitHub, and other version control systems. The video course linked below was created by Alyssa Hursh, an Ada alum and mentor and software engineer at Amazon. This comprehensive git course is based on Alyssa's extensive experience mentoring Ada interns at Amazon. Completion of this course will help set up Ada interns for success at Amazon.
 
 ## Video Course
 

--- a/internship-prep/vim.md
+++ b/internship-prep/vim.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-In internship, we will learn to use many new tools. One of the tools will be a new Integrated Development Environment (IDE) or text editor. To practice quickly getting up to speed with an new tool, in this lesson we will complete a **vim** crash course. 
+In internship, we will learn to use many new tools. One of the tools will be a new Integrated Development Environment (IDE) or text editor. To practice quickly getting up to speed with a new tool, in this lesson we will complete a **vim** crash course. 
 
 **Vim** is a powerful and commonly used text editor that is run from the terminal. To learn the basics of using **vim**, complete a short [Vim Crash Course](http://alyssahursh.com/docs/vim-crash-course.html). This resource was created by Alyssa Hursh, an Ada alum and mentor and software engineer at Amazon.
 


### PR DESCRIPTION
**Summary of changes**
- Capitalize Git and GitHub
- Fix typo in vim intro